### PR TITLE
Fix circular dependency issues (fix #14)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -179,7 +179,7 @@ in {
 
       # These attrs have already been created in pre-processing
       # Cyclic dependencies has deterministic ordering so they will end up with the exact same attributes
-      name = lib.concatStringsSep "-" (builtins.map (attr: pnpmlock.packages."${attr}".name) pkgInfo.constituents);
+      name = builtins.substring 0 207 (lib.concatStringsSep "-" (builtins.map (attr: pnpmlock.packages."${attr}".name) pkgInfo.constituents));
       version = if !hasCycle then pkgInfo.version else "cyclic";
       pname = lib.concatStringsSep "-" (builtins.map (attr: pnpmlock.packages."${attr}".pname) pkgInfo.constituents);
 

--- a/derivation.nix
+++ b/derivation.nix
@@ -66,7 +66,7 @@ in {
     sourceRoot = ".";
     postUnpack = ''
       mkdir -p node_modules
-      mv pnpm2nix-source-*/* node_modules/
+      cp -R pnpm2nix-source-*/* node_modules/
       rm -r pnpm2nix-source-*
     '';
 
@@ -77,9 +77,10 @@ in {
           if test ! -L "$module"; then
             # Check for nested directories (npm calls this scopes)
             if test "$(echo "$module" | grep -o '@')" = '@'; then
-              outdir=$(dirname node_modules/${dep.pname})
+              scope=$(echo "${dep.pname}" | cut -d/ -f 1)
+              outdir=node_modules/$scope
               mkdir -p "$outdir"
-              ln -s "$module" $outdir/$(basename "$module")
+              ln -sf "$module" "$outdir"
             else
               ln -s "$module" node_modules/$(basename "$module")
             fi

--- a/derivation.nix
+++ b/derivation.nix
@@ -82,7 +82,7 @@ in {
               mkdir -p "$outdir"
               ln -sf "$module" "$outdir"
             else
-              ln -s "$module" node_modules/$(basename "$module")
+              ln -sf "$module" node_modules/ || :
             fi
           fi
         done

--- a/pnpmlock.nix
+++ b/pnpmlock.nix
@@ -214,9 +214,9 @@ let
       #
       # The list is sorted to provide the exact same ordering no matter
       # where the cycle was entered
-      cycleConstituents = lib.lists.sort (a: b: a < b) (if hasCycle then
+      cycleConstituents = lib.unique (lib.lists.sort (a: b: a < b) (if hasCycle then
         (lib.lists.sublist cycleIndex (lib.lists.length visitStack) visitStack)
-        else [ pkgAttr ]);
+        else [ pkgAttr ]));
 
       # Modify the accumulator with constituents
       #
@@ -228,7 +228,7 @@ let
         dependencies = lib.filter (depAttr: !(lib.elem depAttr cycleConstituents)) constituentDeps;
       in {
         "${attrName}" = (constituent // {
-          constituents = cycleConstituents;
+          constituents = lib.unique ((if builtins.hasAttr "constituents" constituent then constituent.constituents else []) ++ cycleConstituents);
           inherit dependencies;
         });
       }))) acc cycleConstituents;


### PR DESCRIPTION
This is my attempt at resolving some issues with circular dependencies I experienced. I don't really see this PR as being perfect as I have very little idea of what I even did to resolve the issues, and honestly never figured out how the constituent system even worked.

One of the things I had to do was limit the name length of packages which is discomforting for a few reasons, but I don't know a better way to deal with.

I tweaked the constituent system until it looked "good" in a REPL (showing showing the previously missing dependencies under constituents, without erroring with infinite recursion), then I updated some of the scripts to handle namespaced packages properly, as it used to have issues linking multiple packages under the same namespace to the same Nix package.

This is probably better as a reference than an actual PR unless it looks all good to you.

I don't know how to test the results of this for accuracy well, but it was able to install Webpack and a bunch of my other dependencies, and work correctly (build system for an Elm project).