### PR TITLE
Update wildcardMatch regex for Darwin

### DIFF
--- a/semver.nix
+++ b/semver.nix
@@ -25,7 +25,7 @@ let
 
     dropWildcardPrecision = f: version: constraint: let
       # TODO: some stricter trailing-wildcard matching
-      wildcardMatch = match "([^0-9x*]*)([0-9]\\.[0-9]\\.[0-9]|[0-9]\\.[0-9]|[0-9])?([.x*]*)" constraint;
+      wildcardMatch = match "([^0-9x*]*)([0-9]+\\.[0-9]+\\.[0-9]+|[0-9]+\\.[0-9]+|[0-9]+)?([.x*]*)" constraint;
       matchPart = (elemAt wildcardMatch 1);
       shortConstraint = if matchPart != null then matchPart else "";
       shortVersion = builtins.substring 0 (builtins.stringLength shortConstraint) version;

--- a/semver.nix
+++ b/semver.nix
@@ -25,7 +25,7 @@ let
 
     dropWildcardPrecision = f: version: constraint: let
       # TODO: some stricter trailing-wildcard matching
-      wildcardMatch = match "(.*?)([0-9]\\.[0-9]\\.[0-9]|[0-9]\\.[0-9]|[0-9])?([.x*]*)" constraint;
+      wildcardMatch = match "([^0-9x*]*)([0-9]\\.[0-9]\\.[0-9]|[0-9]\\.[0-9]|[0-9])?([.x*]*)" constraint;
       matchPart = (elemAt wildcardMatch 1);
       shortConstraint = if matchPart != null then matchPart else "";
       shortVersion = builtins.substring 0 (builtins.stringLength shortConstraint) version;


### PR DESCRIPTION
This fixes `invalid regular expression '(.*?)([0-9]\.[0-9]\.[0-9]|[0-9]\.[0-9]|[0-9])?([.x*]*)', at …/semver.nix:28:23`