### PR TITLE
Stronger semver parsing

### DIFF
--- a/semver.nix
+++ b/semver.nix
@@ -1,108 +1,121 @@
 { pkgs ? import <nixpkgs> {}, lib ? pkgs.lib }:
-
 let
   inherit (builtins) elemAt match;
 
   # Replace a list entry at defined index with set value
-  ireplace = idx: value: list: let
-    inherit (builtins) genList length;
-  in
-  genList (i: if i == idx then value else (elemAt list i)) (length list);
+  ireplace = idx: value: list:
+    let
+      inherit (builtins) genList length;
+    in genList (i: if i == idx then value else (elemAt list i)) (length list);
+
+  orBlank = x: if x != null then x else "";
 
   operators = let
     mkComparison = ret: version: v:
-    let
-      x = 1;
-    in
-    builtins.compareVersions version v == ret;
+      let
+        x = 1;
+      in builtins.compareVersions version v == ret;
 
-    mkIdxComparison = idx: version: v: let
-      ver = builtins.splitVersion v;
-      minor = builtins.toString (lib.toInt (elemAt ver idx) + 1);
-      upper = builtins.concatStringsSep "." (ireplace idx minor ver);
-    in
-    operators.">=" version v && operators."<" version upper;
+    mkIdxComparison = idx: version: v:
+      let
+        ver = builtins.splitVersion v;
+        minor = builtins.toString (lib.toInt (elemAt ver idx) + 1);
+        upper = builtins.concatStringsSep "." (ireplace idx minor ver);
+      in operators.">=" version v && operators."<" version upper;
 
-    dropWildcardPrecision = f: version: constraint: let
-      # TODO: some stricter trailing-wildcard matching
-      wildcardMatch = match "([^0-9x*]*)([0-9]+\\.[0-9]+\\.[0-9]+|[0-9]+\\.[0-9]+|[0-9]+)?([.x*]*)" constraint;
-      matchPart = (elemAt wildcardMatch 1);
-      shortConstraint = if matchPart != null then matchPart else "";
-      shortVersion = builtins.substring 0 (builtins.stringLength shortConstraint) version;
-    in
-    f shortVersion shortConstraint;
+    dropWildcardPrecision = f: version: constraint:
+      let
+        wildcardMatch = (
+          match
+            "([^0-9x*]*)((0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)|(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)|(0|[1-9][0-9]*)){0,1}([.x*]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)){0,1}(\\+([0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*)){0,1}"
+            constraint
+        );
+        matchPart = (elemAt wildcardMatch 1);
+        shortConstraint = if matchPart != null then matchPart else "";
+        shortVersion =
+          builtins.substring 0 (builtins.stringLength shortConstraint) version;
+      in f shortVersion shortConstraint;
   in {
     # Prefix operators
     "==" = dropWildcardPrecision (mkComparison 0);
     ">" = dropWildcardPrecision (mkComparison 1);
     "<" = dropWildcardPrecision (mkComparison (-1));
-    "!=" = v: c: ! operators."==" v c;
+    "!=" = v: c: !operators."==" v c;
     ">=" = v: c: operators."==" v c || operators.">" v c;
     "<=" = v: c: operators."==" v c || operators."<" v c;
     # Semver specific operators
-    "~" = mkIdxComparison 1;  #
+    "~" = mkIdxComparison 1;
     "^" = mkIdxComparison 0;
   };
 
   re = {
     operators = "([=><!~^]+)";
-    version = "([0-9.*x]+|[0-9.*x]+-[a-z0-9]+)";
+    version =
+      "((0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)|(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)|(0|[1-9][0-9]*)){0,1}([.x*]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)){0,1}(\\+([0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*)){0,1}";
   };
 
-  parseConstraint = constraintStr: let
-    # The common prefix operators
-    mPre = match "${re.operators} *${re.version}" constraintStr;
-    # There is an upper bound to the operator (this implementation is a bit hacky)
-    mUpperBound = match "${re.operators} *${re.version} *< *${re.version}" constraintStr; 
-    # There is also an infix operator to match ranges
-    mIn = match "${re.version} - *${re.version}" constraintStr;
-    # There is no operators
-    mNone = match "${re.version}" constraintStr;
-  in (
-    if mPre != null then {
-      ops.t = elemAt mPre 0;
-      v = elemAt mPre 1;
-    }
-    # Infix operators are range matches
-    else if mIn != null then {
-      ops = {
-        t = "-";
-        l = ">=";
-        u = "<=";
-      };
-      v = {
-        vl = (elemAt mIn 0);
-        vu = (elemAt mIn 1);
-      };
-    }
-    else if mUpperBound != null then {
-      ops = {
-        t = "-";
-        l = (elemAt mUpperBound 0);
-        u = "<";
-      };
-      v = {
-        vl = (elemAt mUpperBound 1);
-        vu = (elemAt mUpperBound 2);
-      };
-    }
-    else if mNone != null then {
-      ops.t = "==";
-      v = elemAt mNone 0;
-    }
-    else throw "Constraint \"${constraintStr}\" could not be parsed");
+  reLengths = {
+    operators = 1;
+    version = 16;
+  };
+
+  parseConstraint = constraintStr:
+    let
+      # The common prefix operators
+      mPre = match "${re.operators} *${re.version}" constraintStr;
+      # There is an upper bound to the operator (this implementation is a bit hacky)
+      mUpperBound =
+        match "${re.operators} *${re.version} *< *${re.version}" constraintStr;
+      # There is also an infix operator to match ranges
+      mIn = match "${re.version} - *${re.version}" constraintStr;
+      # There is no operators
+      mNone = match "${re.version}" constraintStr;
+    in (
+      if mPre != null then {
+        ops.t = elemAt mPre 0;
+        v = orBlank (elemAt mPre reLengths.operators);
+      }
+        # Infix operators are range matches
+      else if mIn != null then {
+        ops = {
+          t = "-";
+          l = ">=";
+          u = "<=";
+        };
+        v = {
+          vl = orBlank (elemAt mIn 0);
+          vu = orBlank (elemAt mIn reLengths.version);
+        };
+      } else if mUpperBound != null then {
+        ops = {
+          t = "-";
+          l = (elemAt mUpperBound 0);
+          u = "<";
+        };
+        v = {
+          vl = orBlank (elemAt mUpperBound reLengths.operators);
+          vu = orBlank (elemAt mUpperBound (reLengths.operators + reLengths.version));
+        };
+      } else if mNone != null then {
+        ops.t = "==";
+        v = orBlank (elemAt mNone 0);
+      } else
+        throw ''Constraint "${constraintStr}" could not be parsed''
+    );
 
   satisfiesSingle = version: constraint:
-  let
-    inherit (parseConstraint constraint) ops v;
-  in
-  if ops.t == "-" then
-    (operators."${ops.l}" version v.vl && operators."${ops.u}" version v.vu)
-  else
-    operators."${ops.t}" version v;
+    let
+      inherit (parseConstraint constraint) ops v;
+    in if ops.t == "-" then
+      (operators."${ops.l}" version v.vl && operators."${ops.u}" version v.vu)
+    else
+      operators."${ops.t}" version v;
 
   satisfies = version: constraint:
-    # TODO: use a regex for the split
-    builtins.length (builtins.filter (c: satisfiesSingle version c) (lib.splitString " || " constraint)) > 0;
-
-in { inherit satisfies; }
+  # TODO: use a regex for the split
+    builtins.length (
+      builtins.filter (c: satisfiesSingle version c)
+        (lib.splitString " || " constraint)
+    ) > 0;
+in
+{ inherit satisfies; }


### PR DESCRIPTION
I was still having some issues with the weirder forms of semver versions, so decided to take a new approach to try and deal with this a little better. I found a POSIX-compatible Regex for semver parsing, adapted it to support the prefixes, and allow the version to be of any length `1`, `1.0`, `1.0.0`, etc (it was only designed to match versions, not bounds). This Regex also has a _lot_ more capturing groups, and can capture a little less than expected, so I also had to adapt some of the other logic.

I'm not entirely confident that I didn't mess up at least one of the indexes, plus my editor kindly updated all the formatting before I noticed (using nixpkgs-fmt), so I can either revert those changes by hand, or maybe this project could adopt either nixpkgs-fmt or nixfmt.

A new pair of eyes on these changes would be great, anecdotally it seems better as is now able to pull some missbehaving pnpm locks, but I wouldn't want a small miscalculation leading to pulling the wrong version of a package.

Note: I did actually test this on both Darwin and Linux, but I know the Regex backend can differ beyond that too